### PR TITLE
chore: migrate GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - run: npm install
@@ -37,7 +37,7 @@ jobs:
   agent-instructions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Check agent instructions (dogfood)
         uses: malmichaels-gif/agent-instructions-kit@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -26,7 +26,7 @@ jobs:
       - run: npm run build
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
 

--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ outputs:
     description: 'Quality grade (A-F)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 20 JS actions are force-deprecated on GitHub runners on **June 2, 2026** (and removed entirely September 2026). This bumps everything to the current Node 24 majors.

## Changes
| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-node` | v4 | **v6** |
| `softprops/action-gh-release` | v2 | **v3** |
| `action.yml` runtime | `node20` | **`node24`** |

Also bumps the CI `build` job's `node-version` from 20 → 24 to match the release job and the upcoming runner default.

## Notes
- All three external action majors are Node-runtime-only bumps with no API changes (verified against their release notes).
- The Node 24 test run is already validated — `release.yml` ran the full suite on `node-version: 24` during the v0.4.0 publish and passed.
- The dogfood step's `agent-instructions-kit@v0` warning clears on the **next release**, when the moving `v0` tag is repointed to a commit containing the `node24` `action.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)